### PR TITLE
Handle missing static resources with 404 responses

### DIFF
--- a/src/main/java/com/sme/afs/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sme/afs/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.stream.Collectors;
 
@@ -125,6 +126,19 @@ public class GlobalExceptionHandler {
             request.getRequestURI()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
+    }
+
+    // Handle static resource requests that don't exist (e.g., /api/ or /api/swagger-ui.html when resources are not present)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException ex, HttpServletRequest request) {
+        log.debug("Resource not found: {}", request.getRequestURI());
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            "Resource not found",
+            request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/sme/afs/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sme/afs/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.stream.Collectors;
 
@@ -136,6 +137,18 @@ public class GlobalExceptionHandler {
             HttpStatus.NOT_FOUND.value(),
             HttpStatus.NOT_FOUND.getReasonPhrase(),
             "Resource not found",
+            request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException ex, HttpServletRequest request) {
+        log.debug("No handler found: {} {}", request.getMethod(), request.getRequestURI());
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            "Endpoint not found",
             request.getRequestURI()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);


### PR DESCRIPTION
### **User description**
### Summary
This pull request adds handling for `NoResourceFoundException` in the `GlobalExceptionHandler`, ensuring that missing static resources return a 404 response. 

### Changes
- Modified `GlobalExceptionHandler` to catch `NoResourceFoundException` and respond with HTTP 404 codes.


___

### **PR Type**
Bug fix


___

### **Description**
- Add exception handler for missing static resources

- Return proper 404 responses for NoResourceFoundException

- Improve error handling consistency in GlobalExceptionHandler


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NoResourceFoundException"] --> B["GlobalExceptionHandler"] --> C["404 ErrorResponse"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GlobalExceptionHandler.java</strong><dd><code>Add NoResourceFoundException handler for 404 responses</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/sme/afs/exception/GlobalExceptionHandler.java

<ul><li>Import <code>NoResourceFoundException</code> from Spring Web<br> <li> Add new exception handler method for <code>NoResourceFoundException</code><br> <li> Return structured 404 error response with proper logging</ul>


</details>


  </td>
  <td><a href="https://github.com/xrg-experimental/advancedfileserver_backend/pull/5/files#diff-dc25087cfe748ee8a48eb0147e7665f05bc3753663183445e60ff22acb1e533a">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

