### PR TITLE
Refactor shared folder configuration and database schema

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,30 @@
+# CodeRabbit configuration
+language: en-US  # Review language
+reviews:
+    profile: chill  # or "assertive" for more detailed feedback
+    high_level_summary: true
+    poem: false
+    review_status: false
+    auto_review:
+        enabled: true
+        drafts: false  # Don't review draft MRs
+    path_filters:
+        - "src/**"           # Include source code
+        - "user-docs/**"     # Include documentation for the users
+        - ".git*"            # Include .gitattributes and .gitignore
+        - "pom.xml"          # Include Maven configuration
+        - "README.m"         # Include main README
+        - "!docs/old/**"     # Exclude old plans and prompts
+        - "!docs/prompts/**" # Exclude prompts
+        - "!logs/**"         # Exclude log files
+        - "!target/**"       # Exclude build directories
+# also catch leading-dot CI files at repo root
+        - ".gitlab-ci.yml"
+    path_instructions:
+        - path: "**/*.java"
+          instructions: "Focus on understandable code and security best practices"
+    tools:
+        yamllint:
+            enabled: false
+        markdownlint:
+            enabled: false

--- a/afs-srv.iml
+++ b/afs-srv.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="FacetManager">
+    <facet type="jpa" name="JPA">
+      <configuration>
+        <setting name="validation-enabled" value="true" />
+        <setting name="provider-name" value="Hibernate" />
+        <datasource-mapping />
+        <naming-strategy-map />
+      </configuration>
+    </facet>
+  </component>
+</module>

--- a/src/main/java/com/sme/afs/config/SharedFolderConfig.java
+++ b/src/main/java/com/sme/afs/config/SharedFolderConfig.java
@@ -9,8 +9,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
-import java.util.List;
-
 @Slf4j
 @Configuration
 @EnableScheduling
@@ -39,17 +37,5 @@ public class SharedFolderConfig {
             log.debug("Performing periodic shared folder validation");
             validator.validateConfiguration();
         }
-    }
-
-    public void updateConfiguration(List<String> newBasePaths, String newTempPath) {
-        if (!properties.isAllowRuntimeUpdates()) {
-            throw new IllegalStateException("Runtime updates are not allowed");
-        }
-
-        log.info("Updating shared folder configuration");
-        properties.setBasePaths(newBasePaths);
-        properties.setTempPath(newTempPath);
-        validator.validateConfiguration();
-        log.info("Shared folder configuration updated successfully");
     }
 }

--- a/src/main/java/com/sme/afs/config/SharedFolderProperties.java
+++ b/src/main/java/com/sme/afs/config/SharedFolderProperties.java
@@ -4,36 +4,19 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Setter
 @Configuration
 @ConfigurationProperties(prefix = "shared-folder")
 public class SharedFolderProperties {
-    private List<String> basePaths = new ArrayList<>();
-    private String tempPath;
+    private String basePath;
     private boolean validateOnStartup = true;
     private int scanIntervalSeconds = 300;
     private boolean allowRuntimeUpdates = true;
     private boolean validatePermissions = true;
     private boolean createMissingDirectories = true;
-    private int maxBasePaths = 10;
-    private int minBasePaths = 1;
     private String packageOwner;
     private String packageOwnerFull;
     private boolean enforcePackageOwner = true;
-    
-    // For backward compatibility
-    public void setBasePath(String basePath) {
-        this.basePaths = new ArrayList<>();
-        if (basePath != null) {
-            this.basePaths.add(basePath);
-        }
-    }
-    
-    public String getBasePath() {
-        return basePaths.isEmpty() ? null : basePaths.get(0);
-    }
 }

--- a/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
+++ b/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
@@ -36,17 +36,6 @@ public class SharedFolderConfigController {
         return ResponseEntity.ok(SharedFolderConfigResponse.of(configs));
     }
 
-    @GetMapping("/base-paths")
-    public ResponseEntity<SharedFolderConfigResponse> getBasePaths() {
-        List<SharedFolderConfig> basePaths = configService.getBasePaths();
-        return ResponseEntity.ok(SharedFolderConfigResponse.of(basePaths));
-    }
-
-    @GetMapping("/temp-path")
-    public ResponseEntity<SharedFolderConfigResponse> getTempPath() {
-        return ResponseEntity.ok(SharedFolderConfigResponse.of(configService.getTempPath()));
-    }
-
     @PostMapping("/initialize")
     public ResponseEntity<SharedFolderConfigResponse> initializeFromProperties(@AuthenticationPrincipal User user) {
         configService.initializeFromProperties(user);
@@ -114,10 +103,8 @@ public class SharedFolderConfigController {
             @AuthenticationPrincipal User user) {
         
         SharedFolderConfig config = configService.createOrUpdateConfig(
-            request.getPath(), 
-            request.getIsBasePath(), 
-            request.getIsTempPath(), 
-            user
+            request.getPath(),
+                user
         );
         return ResponseEntity.ok(SharedFolderConfigResponse.of(config));
     }

--- a/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
+++ b/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
@@ -49,11 +49,11 @@ public class SharedFolderConfigController {
         // Check if any validations are stale
         LocalDateTime staleThreshold = LocalDateTime.now().minusMinutes(5);
         boolean hasStaleValidations = validations.stream()
-            .anyMatch(v -> v.getLastCheckedAt().isBefore(staleThreshold));
-            
+                .anyMatch(v -> v.getLastCheckedAt() == null || v.getLastCheckedAt().isBefore(staleThreshold));
+
         if (hasStaleValidations) {
-            validator.validateConfiguration();
-            validations = validationRepository.findAll();
+            // Revalidate and persist, then return fresh rows
+            validations = configService.revalidateAll();
         }
         
         return ResponseEntity.ok(SharedFolderConfigResponse.ofValidations(validations));

--- a/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
+++ b/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
@@ -102,9 +102,9 @@ public class SharedFolderConfigController {
     public ResponseEntity<SharedFolderConfigResponse> createConfig(
             @Valid @RequestBody SharedFolderConfigRequest request,
             @AuthenticationPrincipal User user) {
-        
+
         SharedFolderConfig config = configService.createOrUpdateConfig(
-            request.getPath(),
+                request.getPath() != null ? request.getPath().trim() : null,
                 user
         );
         return ResponseEntity.ok(SharedFolderConfigResponse.of(config));

--- a/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
+++ b/src/main/java/com/sme/afs/controller/SharedFolderConfigController.java
@@ -52,8 +52,9 @@ public class SharedFolderConfigController {
                 .anyMatch(v -> v.getLastCheckedAt() == null || v.getLastCheckedAt().isBefore(staleThreshold));
 
         if (hasStaleValidations) {
-            // Revalidate and persist, then return fresh rows
-            validations = configService.revalidateAll();
+            // Revalidate and then return freshly persisted rows
+            configService.revalidateAll();
+            validations = validationRepository.findAll();
         }
         
         return ResponseEntity.ok(SharedFolderConfigResponse.ofValidations(validations));

--- a/src/main/java/com/sme/afs/dto/SharedFolderConfigRequest.java
+++ b/src/main/java/com/sme/afs/dto/SharedFolderConfigRequest.java
@@ -12,6 +12,7 @@ public class SharedFolderConfigRequest {
     @NotNull(message = "isBasePath must be specified")
     private Boolean isBasePath;
     
-    @NotNull(message = "isTempPath must be specified")
-    private Boolean isTempPath;
+    // Note: isTempPath is no longer supported but kept for backward compatibility
+    // Any request with isTempPath=true will be rejected
+    private Boolean isTempPath = false;
 }

--- a/src/main/java/com/sme/afs/dto/SharedFolderConfigRequest.java
+++ b/src/main/java/com/sme/afs/dto/SharedFolderConfigRequest.java
@@ -1,18 +1,10 @@
 package com.sme.afs.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class SharedFolderConfigRequest {
     @NotBlank(message = "Path cannot be empty")
     private String path;
-    
-    @NotNull(message = "isBasePath must be specified")
-    private Boolean isBasePath;
-    
-    // Note: isTempPath is no longer supported but kept for backward compatibility
-    // Any request with isTempPath=true will be rejected
-    private Boolean isTempPath = false;
 }

--- a/src/main/java/com/sme/afs/model/SharedFolderConfig.java
+++ b/src/main/java/com/sme/afs/model/SharedFolderConfig.java
@@ -18,12 +18,6 @@ public class SharedFolderConfig {
     private String path;
 
     @Column(nullable = false)
-    private boolean isBasePath = false;
-
-    @Column(nullable = false)
-    private boolean isTempPath = false;
-
-    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     @Column(nullable = false)

--- a/src/main/java/com/sme/afs/repository/SharedFolderConfigRepository.java
+++ b/src/main/java/com/sme/afs/repository/SharedFolderConfigRepository.java
@@ -9,8 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface SharedFolderConfigRepository extends JpaRepository<SharedFolderConfig, Long> {
-    List<SharedFolderConfig> findByIsBasePath(boolean isBasePath);
-    Optional<SharedFolderConfig> findByIsTempPath(boolean isTempPath);
+    Optional<SharedFolderConfig> findByIsBasePath(boolean isBasePath);
     boolean existsByPath(String path);
     Optional<SharedFolderConfig> findByPath(String path);
 }

--- a/src/main/java/com/sme/afs/repository/SharedFolderConfigRepository.java
+++ b/src/main/java/com/sme/afs/repository/SharedFolderConfigRepository.java
@@ -4,12 +4,9 @@ import com.sme.afs.model.SharedFolderConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SharedFolderConfigRepository extends JpaRepository<SharedFolderConfig, Long> {
-    Optional<SharedFolderConfig> findByIsBasePath(boolean isBasePath);
-    boolean existsByPath(String path);
     Optional<SharedFolderConfig> findByPath(String path);
 }

--- a/src/main/java/com/sme/afs/service/SharedFolderConfigService.java
+++ b/src/main/java/com/sme/afs/service/SharedFolderConfigService.java
@@ -61,7 +61,7 @@ public class SharedFolderConfigService {
         Optional<SharedFolderConfig> existing = configRepository.findByPath(normalizedPathStr);
         SharedFolderConfig config = existing.orElse(new SharedFolderConfig());
 
-        config.setPath(path);
+        config.setPath(normalizedPathStr);
 
         LocalDateTime now = LocalDateTime.now();
         
@@ -84,7 +84,7 @@ public class SharedFolderConfigService {
         validation.setCheckedBy(user);
         
         try {
-            SharedFolderValidation pathValidation = validator.validatePath(path);
+            SharedFolderValidation pathValidation = validator.validatePath(normalizedPathStr);
             validation.setValid(pathValidation.isValid());
             validation.setErrorMessage(pathValidation.getErrorMessage());
             validation.setCanRead(pathValidation.getCanRead());

--- a/src/main/java/com/sme/afs/service/SharedFolderValidator.java
+++ b/src/main/java/com/sme/afs/service/SharedFolderValidator.java
@@ -40,8 +40,8 @@ public class SharedFolderValidator {
         }
 
         // Validate the base path is accessible by package owner
-        if (!properties.getBasePath().isEmpty()) {
-            String path = properties.getBasePath();
+        String path = properties.getBasePath();
+        if (path != null && !path.isBlank()) {
             Path basePath = Path.of(path);
             try {
                 UserPrincipal owner = Files.getOwner(basePath);

--- a/src/main/java/com/sme/afs/service/SharedFolderValidator.java
+++ b/src/main/java/com/sme/afs/service/SharedFolderValidator.java
@@ -10,9 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.UserPrincipal;
 import java.time.LocalDateTime;
@@ -249,15 +247,10 @@ public class SharedFolderValidator {
 
     public static Path validateAndNormalizePath(String pathStr) throws IOException {
         Path path = Path.of(pathStr).normalize().toAbsolutePath();
-
-        // Ensure NOFOLLOW_LINKS option is used when resolving the path
-        BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-
-        // Optionally add additional file attribute checks here if required
-        if (attrs.isSymbolicLink()) {
+        // Block direct symlink targets (content symlinks are caught later)
+        if (Files.isSymbolicLink(path)) {
             throw new IOException("Path traversal via symbolic link is not allowed: " + path);
         }
-
         return path;
     }
 }

--- a/src/main/java/com/sme/afs/service/SharedFolderValidator.java
+++ b/src/main/java/com/sme/afs/service/SharedFolderValidator.java
@@ -92,11 +92,15 @@ public class SharedFolderValidator {
         // Validate package owner first
         validatePackageOwner();
 
-        // Validate the base path
-        validatePath(properties.getBasePath());
-        if (properties.isCreateMissingDirectories()) {
-            validateRequiredStructure(properties.getBasePath());
+        // Validate/create the base path
+        String basePath = properties.getBasePath();
+        if (basePath == null || basePath.isBlank()) {
+            throw new AfsException(ErrorCode.VALIDATION_FAILED, "basePath is not configured");
         }
+        if (properties.isCreateMissingDirectories()) {
+            validateRequiredStructure(basePath);
+        }
+        validatePath(basePath);
     }
 
     private void validateRequiredStructure(String basePath) {

--- a/src/main/java/com/sme/afs/service/SharedFolderValidator.java
+++ b/src/main/java/com/sme/afs/service/SharedFolderValidator.java
@@ -89,7 +89,7 @@ public class SharedFolderValidator {
             }
 
             try (var listing = Files.list(normalizedPath)) {
-                listing.findFirst(); // touch listing to assert access
+                var ignore = listing.findFirst(); // touch listing to assert access
                 validation.setValid(true);
             } catch (SecurityException e) {
                 validation.setValid(false);

--- a/src/main/java/com/sme/afs/service/SharedFolderValidator.java
+++ b/src/main/java/com/sme/afs/service/SharedFolderValidator.java
@@ -251,10 +251,7 @@ public class SharedFolderValidator {
 
     public static Path validateAndNormalizePath(String pathStr) throws IOException {
         Path path = Path.of(pathStr).normalize().toAbsolutePath();
-        // Block direct symlink targets (content symlinks are caught later)
-        if (Files.isSymbolicLink(path)) {
-            throw new IOException("Path traversal via symbolic link is not allowed: " + path);
-        }
-        return path;
+        // Option: resolve the canonical path (follows symlinks)
+        return path.toRealPath();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,10 +85,7 @@ spring:
     activate:
       on-profile: demo
 shared-folder:
-  base-paths:
-    - D:/demo/shared
-    - D:/demo/shared2
-  temp-path: D:/demo/temp
+  base-path: D:/demo/shared
   validate-on-startup: true
   scan-interval-seconds: 300
   allow-runtime-updates: true
@@ -103,7 +100,6 @@ spring:
       on-profile: test
 shared-folder:
   base-path: D:/test/shared
-  temp-path: D:/test/temp
   validate-on-startup: true
   scan-interval-seconds: 300
   allow-runtime-updates: true
@@ -118,7 +114,6 @@ spring:
       on-profile: "!demo & !test"
 shared-folder:
   base-path: /volume1/shared
-  temp-path: /volume1/shared/temp
 
 logging:
   level:

--- a/src/main/resources/db/migration/V1.11__remove_path_type_columns.sql
+++ b/src/main/resources/db/migration/V1.11__remove_path_type_columns.sql
@@ -1,0 +1,9 @@
+-- Remove is_base_path and is_temp_path columns from shared_folder_configs table
+-- Since we only have base paths now, these columns are no longer needed
+
+-- Drop the constraint that referenced these columns
+ALTER TABLE shared_folder_configs DROP CONSTRAINT IF EXISTS check_path_type;
+
+-- Drop the columns
+ALTER TABLE shared_folder_configs DROP COLUMN IF EXISTS is_base_path;
+ALTER TABLE shared_folder_configs DROP COLUMN IF EXISTS is_temp_path;


### PR DESCRIPTION
### Description of the changes

This pull request includes the following updates:
- Added a module configuration file (`afs-srv.iml`) with JPA facet settings.
- Removed the `is_base_path` and `is_temp_path` fields from the `SharedFolderConfig` entity and related logic.
- Unified base and temp paths in `SharedFolderConfig` into a single `basePath` property, simplifying validation and service logic.
- Adjusted the database schema to align with the updated configuration structure.

### Additional context

These changes simplify the shared folder configuration, reduce redundancy in the database schema, and improve maintainability.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OS-aware package-owner access enforcement for the shared base path.
  - Unified path validation with clearer, consistent error messages, automatic normalization, and a revalidation endpoint.

- Refactor
  - Switched to a single base-path model; temp-path and multi-base support removed.
  - Simplified APIs and requests: path-type flags and endpoints for listing base/temp paths removed.

- Chores
  - Configuration consolidated to a single base-path with package-owner settings for demo/test.
  - Database migration removes legacy path-type columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->